### PR TITLE
Moved envs from inline to export

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,8 @@ set -e
 cd /github/workspace/
 
 npm ci --ignore-scripts
-HOMEY_HEADLESS="1" HOMEY_PAT="$1" npx homey app publish
+export HOMEY_HEADLESS="1"
+export HOMEY_PAT="$1"
+npx homey app publish
 
 echo "url=https://tools.developer.homey.app/apps/app/$(cat app.json | jq --raw-output .id)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
It looks like the env variables are no longer passed to the action runner, see stacktrace below.

```
node:internal/readline/interface:564
      throw new ERR_USE_AFTER_CLOSE('readline');
      ^

Error [ERR_USE_AFTER_CLOSE]: readline was closed
    at Interface.pause (node:internal/readline/interface:564:13)
    at PromptUI.close (/github/workspace/node_modules/inquirer/lib/ui/baseUI.js:56:13)
    at PromptUI.onForceClose (/github/workspace/node_modules/inquirer/lib/ui/baseUI.js:34:10)
    at process.emit (node:events:520:35) {
  code: 'ERR_USE_AFTER_CLOSE'
}

Node.js v24.11.1
? Do you want to update your app's version number? (current v1.8.1) (Y/n) 
```